### PR TITLE
Improve the process of clearing the cache.

### DIFF
--- a/src/MageTest/MagentoExtension/Service/Cache/BaseCache.php
+++ b/src/MageTest/MagentoExtension/Service/Cache/BaseCache.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * BehatMage
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License, that is bundled with this
+ * package in the file LICENSE.
+ * It is also available through the world-wide-web at this URL:
+ *
+ * http://opensource.org/licenses/MIT
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email
+ * to <magetest@sessiondigital.com> so we can send you a copy immediately.
+ *
+ * @category   MageTest
+ * @package    MagentoExtension
+ * @subpackage Service\Cache
+ *
+ * @copyright  Copyright (c) 2012-2013 MageTest team and contributors.
+ */
+namespace MageTest\MagentoExtension\Service\Cache;
+
+use Mage_Core_Model_App;
+
+/**
+ * ConfigurationCache
+ *
+ * @category   MageTest
+ * @package    MagentoExtension
+ * @subpackage Service\Cache
+ *
+ * @author     MageTest team (https://github.com/MageTest/BehatMage/contributors)
+ */
+abstract class BaseCache
+{
+    /**
+     * List of cache types to clear.
+     *
+     * For example:
+     * - config
+     * - block_html
+     * - layout
+     * - translate
+     *
+     * @var array
+     */
+    protected $cacheTypes = array();
+
+    /**
+     * Internal instance of MageApp
+     *
+     * @var Mage_Core_Model_App
+     **/
+    protected $mageApp;
+
+
+    public function __construct(Mage_Core_Model_App $mageApp)
+    {
+        $this->mageApp = $mageApp;
+    }
+
+    public function clear()
+    {
+        $this->mageApp->cleanCache($this->getCacheTags());
+    }
+
+    /**
+     * All listed types must be declared under global/cache/types
+     *
+     * @return array
+     */
+    private function getCacheTags()
+    {
+        $tags = array();
+        foreach ($this->cacheTypes as $type) {
+            $tags = array_merge($tags, $this->mageApp->getCacheInstance()->getTagsByType($type));
+        }
+        return $tags;
+    }
+}

--- a/src/MageTest/MagentoExtension/Service/Cache/BlockHtmlCache.php
+++ b/src/MageTest/MagentoExtension/Service/Cache/BlockHtmlCache.php
@@ -35,5 +35,5 @@ use Mage_Core_Model_App;
  */
 class ConfigurationCache extends BaseCache
 {
-    protected $cacheTypes = array('config');
+    protected $cacheTypes = array('block_html');
 }

--- a/src/MageTest/MagentoExtension/Service/Cache/ConfigurationCache.php
+++ b/src/MageTest/MagentoExtension/Service/Cache/ConfigurationCache.php
@@ -22,8 +22,6 @@
  */
 namespace MageTest\MagentoExtension\Service\Cache;
 
-use Mage_Core_Model_App;
-
 /**
  * ConfigurationCache
  *

--- a/src/MageTest/MagentoExtension/Service/Cache/LayoutCache.php
+++ b/src/MageTest/MagentoExtension/Service/Cache/LayoutCache.php
@@ -31,7 +31,7 @@ namespace MageTest\MagentoExtension\Service\Cache;
  *
  * @author     MageTest team (https://github.com/MageTest/BehatMage/contributors)
  */
-class BlockHtmlCache extends BaseCache
+class LayoutCache extends BaseCache
 {
-    protected $cacheTypes = array('block_html');
+    protected $cacheTypes = array('layout');
 }


### PR DESCRIPTION
Each cache type can consist of one or more cache tags. This patch uses the cache tags
that have been configured in magento for each cache segment instead of using a single
hardcoded 'config' tag.

This touches on issue #19, but doesn't resolve it completely yet.
