### PR TITLE
Add validation of the route before visiting

### DIFF
--- a/src/MageTest/MagentoExtension/Context/MagentoContext.php
+++ b/src/MageTest/MagentoExtension/Context/MagentoContext.php
@@ -115,7 +115,7 @@ class MagentoContext extends RawMinkContext implements MagentoAwareInterface
         $m = explode('/', ltrim($page, '/'));
         if ($this->app->getFrontController()->getRouter('standard')->getRouteByFrontName($m[0])) {
             $processedUri = "/{$m[0]}/{$m[1]}";
-            $this->getSession()->visit($processedUri);
+            $this->getSession()->visit($this->locatePath($processedUri));
         } else {
             $xml = <<<CONF
 <frontend>
@@ -130,12 +130,14 @@ class MagentoContext extends RawMinkContext implements MagentoAwareInterface
     </routers>
 </frontend>
 CONF;
+            $alternate = "Or if you are testing a CMS page ensure the URL is corrrect and the Page is enabled.";
             $config = sprintf((string) $xml, $m[0]);
             throw new \InvalidArgumentException(
                 sprintf(
-                    "Missing route for the URI '%s', You should the following XML to your config.xml \n %s",
+                    "Missing route for the URI '%s', You should the following XML to your config.xml \n %s \n\n%s",
                     $page,
-                    $config
+                    $config,
+                    $alternate
                 )
             );
         }

--- a/src/MageTest/MagentoExtension/Context/MagentoContext.php
+++ b/src/MageTest/MagentoExtension/Context/MagentoContext.php
@@ -106,11 +106,39 @@ class MagentoContext extends RawMinkContext implements MagentoAwareInterface
     }
 
     /**
-     * @When /^I am on "([^"]*)"$/
+     * @Given /^(?:|I )am on "(?P<page>[^"]+)"$/
+     * @When /^(?:|I )go to "(?P<page>[^"]+)"$/
      */
-    public function iAmOn($uri)
+    public function iAmOn($page)
     {
-        $this->getSession()->visit($this->locatePath($uri));
+        $urlModel = new \Mage_Core_Model_Url();
+        $m = explode('/', ltrim($page, '/'));
+        if ($this->app->getFrontController()->getRouter('standard')->getRouteByFrontName($m[0])) {
+            $processedUri = "/{$m[0]}/{$m[1]}";
+            $this->getSession()->visit($processedUri);
+        } else {
+            $xml = <<<CONF
+<frontend>
+    <routers>
+        <{module_name}>
+            <use>standard</use>
+            <args>
+                <module>{module_name}</module>
+                <frontName>%s</frontName>
+            </args>
+        <{module_name}>
+    </routers>
+</frontend>
+CONF;
+            $config = sprintf((string) $xml, $m[0]);
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Missing route for the URI '%s', You should the following XML to your config.xml \n %s",
+                    $page,
+                    $config
+                )
+            );
+        }
     }
 
     /**

--- a/src/MageTest/MagentoExtension/Context/MagentoContext.php
+++ b/src/MageTest/MagentoExtension/Context/MagentoContext.php
@@ -130,7 +130,7 @@ class MagentoContext extends RawMinkContext implements MagentoAwareInterface
     </routers>
 </frontend>
 CONF;
-            $alternate = "Or if you are testing a CMS page ensure the URL is corrrect and the Page is enabled.";
+            $alternate = "Or if you are testing a CMS page ensure the URL is correct and the Page is enabled.";
             $config = sprintf((string) $xml, $m[0]);
             throw new \InvalidArgumentException(
                 sprintf(


### PR DESCRIPTION
Add validation against the standard router object to ensure that
when we call session->visit($url) we provide feedback rather
than a false positive with 404s returned for missing routes.

The exception also include the correct XML config that is required
to pass this error.
