### PR TITLE
Add product to all websites in order to make it visible

### DIFF
--- a/spec/MageTest/MagentoExtension/Fixture/ProductSpec.php
+++ b/spec/MageTest/MagentoExtension/Fixture/ProductSpec.php
@@ -76,6 +76,8 @@ class ProductSpec extends ObjectBehavior
             'sku' => 'sdf'
         );
 
+        $this->productModel->shouldReceive('setWebsiteIds')->with(array())
+            ->once()->andReturn($this->productModel)->ordered();
         $this->productModel->shouldReceive('setData')
             ->with(\Mockery::any())->once()->andReturn($this->productModel)->ordered();
         $this->productModel->shouldReceive('save')->once()->andReturn(true)->ordered();
@@ -106,6 +108,8 @@ class ProductSpec extends ObjectBehavior
             'sku' => $data['sku']
         );
 
+        $this->productModel->shouldReceive('setWebsiteIds')->with(array())
+            ->once()->andReturn($this->productModel)->ordered();
         $this->productModel->shouldReceive('setData')
             ->with(\Mockery::any())->once()->andReturn($this->productModel)->ordered();
         $this->productModel->shouldReceive('save')->once()->andReturn(true)->ordered();
@@ -141,6 +145,8 @@ class ProductSpec extends ObjectBehavior
 
         $this->productModel->shouldReceive('getData')
             ->once()->andReturn(array('loaded_attr' => 27));
+        $this->productModel->shouldReceive('setWebsiteIds')->with(array())
+            ->once()->andReturn($this->productModel)->ordered();
         $this->productModel->shouldReceive('setData')
             ->with(\Mockery::any())->once()->andReturn($this->productModel)->ordered();
         $this->productModel->shouldReceive('save')->once()->andReturn(true)->ordered();
@@ -156,6 +162,8 @@ class ProductSpec extends ObjectBehavior
             'sku' => 'sku'.time()
         );
 
+        $this->productModel->shouldReceive('setWebsiteIds')->with(array())
+            ->once()->andReturn($this->productModel)->ordered();
         $this->productModel->shouldReceive('setData')->once()->andReturn($this->productModel)->ordered();
         $this->productModel->shouldReceive('save')->once()->andReturn(true)->ordered();
         $this->productModel->shouldReceive('getId')->once()->andReturn(554)->ordered();

--- a/src/MageTest/MagentoExtension/Fixture/Product.php
+++ b/src/MageTest/MagentoExtension/Fixture/Product.php
@@ -67,7 +67,14 @@ class Product implements FixtureInterface
         $this->validateAttributes(array_keys($attributes));
 
         \Mage::app()->setCurrentStore(\Mage_Core_Model_App::ADMIN_STORE_ID);
-        $this->model->setData($this->mergeAttributes($attributes))->save();
+
+        $this->model
+            ->setWebsiteIds(array_map(function($website) {
+                return $website->getId();
+            }, \Mage::app()->getWebsites()))
+            ->setData($this->mergeAttributes($attributes))
+            ->save();
+
         \Mage::app()->setCurrentStore(\Mage_Core_Model_App::DISTRO_STORE_ID);
 
         return $this->model->getId();


### PR DESCRIPTION
When a product fixture is added it should also be added to all the websites by default so that I can immediately view the product page in the next step (otherwise it is not visible).
