### PR TITLE
Don't add stock_data attribute if is_in_stock was not specified

### DIFF
--- a/src/MageTest/MagentoExtension/Context/MagentoContext.php
+++ b/src/MageTest/MagentoExtension/Context/MagentoContext.php
@@ -167,12 +167,18 @@ CONF;
         $hash = $table->getHash();
         $fixtureGenerator = $this->factory->create('product');
         foreach ($hash as $row) {
-            $row['stock_data'] = array();
             if (isset($row['is_in_stock'])) {
-                $row['stock_data']['is_in_stock'] = $row['is_in_stock'];
-            }
-            if (isset($row['is_in_stock'])) {
-                $row['stock_data']['qty'] = $row['qty'];
+                if (!isset($row['qty'])) {
+                    throw new \InvalidArgumentException('You have specified is_in_stock but not qty, please add value for qty.');
+                };
+
+                $row['stock_data'] = array(
+                    'is_in_stock' => $row['is_in_stock'],
+                    'qty' => $row['qty']
+                );
+
+                unset($row['is_in_stock']);
+                unset($row['qty']);
             }
 
             $fixtureGenerator->create($row);


### PR DESCRIPTION
"Given the following products exist" step was causing the stock_data attribute to be created regardless of whether is_in_stock was specified in the table. This in turn cause an empty stock_data attribute to override the default attribute of stock_data (with is_in_stock = 1, qty = 99999).
Now stock_data is taken from the table if is_in_stock/qty are provided, and uses defaults correctly if not.
Also, user should be prompted to provide qty if is_in_stock is specified.
