### PR TITLE
Fixing the secret key, and url to be visited.

### DIFF
--- a/src/MageTest/MagentoExtension/Context/MagentoContext.php
+++ b/src/MageTest/MagentoExtension/Context/MagentoContext.php
@@ -78,8 +78,8 @@ class MagentoContext extends RawMinkContext implements MagentoAwareInterface
         $m = explode('/', ltrim($uri, '/'));
         // Check if frontName matches a configured admin route
         if ($this->app->getFrontController()->getRouter('admin')->getRouteByFrontName($m[0])) {
-            $processedUri = "/{$m[0]}/{$m[1]}/{$m[2]}/key/".$urlModel->getSecretKey($m[0], $m[1])."/{$m[2]}";
-            $this->getSession()->visit($processedUri);
+            $processedUri = "/{$m[0]}/{$m[1]}/{$m[2]}/key/".$urlModel->getSecretKey($m[1], $m[2]);
+            $this->getSession()->visit($this->locatePath($processedUri));
         } else {
             throw new \InvalidArgumentException('$uri parameter should start with a valid admin route and contain controller and action elements');
         }


### PR DESCRIPTION
I noticed `$processedUri` ends up looking like `/[adminRouter]/[controller]/[action]/key/[key]/[action]`

I also noticed, when the key is generated, it is generated using just the admin router. Which is incorrect, it should be generated using either just the controller, or the controller and action.

Finally, when `$this->getSession()->visit($processedUri)` is run, for me, the url generated looked like: `http://localhost/admin/[controller]/[action]/key/[key]/[action]/`. The expected result was: `http://mymachine.local/myproject/admin/[controller]/[action]/key/[key]/`. Passing `$processedUri` through `$this->locatePath()` fixed the issue.
