### PR TITLE
Add image option to product fixture

### DIFF
--- a/src/MageTest/MagentoExtension/Fixture/Product.php
+++ b/src/MageTest/MagentoExtension/Fixture/Product.php
@@ -77,8 +77,16 @@ class Product implements FixtureInterface
             ->setWebsiteIds(array_map(function($website) {
                 return $website->getId();
             }, \Mage::app()->getWebsites()))
-            ->setData($this->mergeAttributes($attributes))
-            ->save();
+            ->setData($this->mergeAttributes($attributes));
+
+            if (!empty($attributes['image'])) {
+                $imagePath = getcwd() . '/' . $attributes['image'];
+                $visibility =array('thumbnail', 'small_image', 'image');
+                $this->model
+                    ->addImageToMediaGallery($imagePath, $visibility, false, false);
+            }
+
+            $this->model->save();
 
         \Mage::app()->setCurrentStore(\Mage_Core_Model_App::DISTRO_STORE_ID);
 


### PR DESCRIPTION
Update the product fixture so that when creating a product you are now able to specify images that should be added to the product. 
