### PR TITLE
Added created_at to product default attributes

### DIFF
--- a/src/MageTest/MagentoExtension/Fixture/Product.php
+++ b/src/MageTest/MagentoExtension/Fixture/Product.php
@@ -156,6 +156,7 @@ class Product implements FixtureInterface
         }
 
         return $this->defaultAttributes[$this->model->getTypeId()] = array_merge($attributeCodes, array(
+            'created_at' => strtotime('now'),
             'sku' => '',
             'attribute_set_id' => $this->retrieveDefaultAttributeSetId(),
             'name' => 'product name',


### PR DESCRIPTION
Adding this prevents "No date part in '' found" Zend_Locale exception when creating product fixtures. Tested on Mage EE v1.14.
