### PR TITLE
Refactor Product fixture, introduce helpers

### DIFF
--- a/spec/MageTest/MagentoExtension/Fixture/ProductSpec.php
+++ b/spec/MageTest/MagentoExtension/Fixture/ProductSpec.php
@@ -26,7 +26,6 @@ use MageTest\MagentoExtension\Helper\Website;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
-
 /**
  * ProductSpec
  *
@@ -51,9 +50,16 @@ class ProductSpec extends ObjectBehavior
         $websiteHelper->shouldReceive('getWebsiteIds')->andReturn(array());
         $websiteHelper->shouldReceive('getWebsites')->andReturn(array());
 
-        $factory = function () use ($productModel) { return $productModel; };
+        $serviceContainer = array(
+            'productModel'  => function() use($productModel) {
+                    return $productModel;
+                },
+            'websiteHelper' => function() use($websiteHelper) {
+                    return $websiteHelper;
+                }
+        );
 
-        $this->beConstructedWith($factory, $websiteHelper);
+        $this->beConstructedWith($serviceContainer);
 
         $entityType = \Mockery::mock(new \Mage_Eav_Model_Entity_Type);
         $entityType->shouldReceive('getDefaultAttributeSetId')->andReturn(7);
@@ -68,18 +74,18 @@ class ProductSpec extends ObjectBehavior
     function it_should_create_a_product_given_all_required_attributes()
     {
         $data = array(
-            'attribute_set_id' => 7,
-            'name' => 'product name',
-            'weight' => 2,
-            'visibility'=> \Mage_Catalog_Model_Product_Visibility::VISIBILITY_BOTH,
-            'status' => \Mage_Catalog_Model_Product_Status::STATUS_ENABLED,
-            'price' => 100,
-            'description' => 'Product description',
+            'attribute_set_id'  => 7,
+            'name'              => 'product name',
+            'weight'            => 2,
+            'visibility'        => \Mage_Catalog_Model_Product_Visibility::VISIBILITY_BOTH,
+            'status'            => \Mage_Catalog_Model_Product_Status::STATUS_ENABLED,
+            'price'             => 100,
+            'description'       => 'Product description',
             'short_description' => 'Product short description',
-            'tax_class_id' => 1,
-            'type_id' => \Mage_Catalog_Model_Product_Type::TYPE_SIMPLE,
-            'stock_data' => array( 'is_in_stock' => 1, 'qty' => 99999 ),
-            'sku' => 'sdf'
+            'tax_class_id'      => 1,
+            'type_id'           => \Mage_Catalog_Model_Product_Type::TYPE_SIMPLE,
+            'stock_data'        => array( 'is_in_stock' => 1, 'qty' => 99999 ),
+            'sku'               => 'sdf'
         );
 
         $this->productModel->shouldReceive('setWebsiteIds')->with(array())
@@ -101,18 +107,18 @@ class ProductSpec extends ObjectBehavior
         );
 
         $expected = array(
-            'attribute_set_id' => 7,
-            'name' => 'product name',
-            'weight' => 2,
-            'visibility'=> \Mage_Catalog_Model_Product_Visibility::VISIBILITY_BOTH,
-            'status' => \Mage_Catalog_Model_Product_Status::STATUS_ENABLED,
-            'price' => 100,
-            'description' => 'Product description',
+            'attribute_set_id'  => 7,
+            'name'              => 'product name',
+            'weight'            => 2,
+            'visibility'        => \Mage_Catalog_Model_Product_Visibility::VISIBILITY_BOTH,
+            'status'            => \Mage_Catalog_Model_Product_Status::STATUS_ENABLED,
+            'price'             => 100,
+            'description'       => 'Product description',
             'short_description' => 'Product short description',
-            'tax_class_id' => 1,
-            'type_id' => \Mage_Catalog_Model_Product_Type::TYPE_SIMPLE,
-            'stock_data' => array( 'is_in_stock' => 1, 'qty' => 99999 ),
-            'sku' => $data['sku']
+            'tax_class_id'      => 1,
+            'type_id'           => \Mage_Catalog_Model_Product_Type::TYPE_SIMPLE,
+            'stock_data'        => array( 'is_in_stock' => 1, 'qty' => 99999 ),
+            'sku'               => $data['sku']
         );
 
         $this->productModel->shouldReceive('setWebsiteIds')->with(array())
@@ -132,24 +138,23 @@ class ProductSpec extends ObjectBehavior
             'sku' => 'sku1'
         );
 
-      $expectedData = array(
-            'attribute_set_id' => 7,
-            'name' => 'product name',
-            'weight' => 2,
-            'visibility'=> \Mage_Catalog_Model_Product_Visibility::VISIBILITY_BOTH,
-            'status' => \Mage_Catalog_Model_Product_Status::STATUS_ENABLED,
-            'price' => 100,
-            'description' => 'Product description',
+        $expectedData = array(
+            'attribute_set_id'  => 7,
+            'name'              => 'product name',
+            'weight'            => 2,
+            'visibility'        => \Mage_Catalog_Model_Product_Visibility::VISIBILITY_BOTH,
+            'status'            => \Mage_Catalog_Model_Product_Status::STATUS_ENABLED,
+            'price'             => 100,
+            'description'       => 'Product description',
             'short_description' => 'Product short description',
-            'tax_class_id' => 1,
-            'loaded_attr' => 27,
-            'type_id' => \Mage_Catalog_Model_Product_Type::TYPE_SIMPLE,
-            'stock_data' => array( 'is_in_stock' => 1, 'qty' => 99999 ),
-            'sku' => $data['sku']
+            'tax_class_id'      => 1,
+            'loaded_attr'       => 27,
+            'type_id'           => \Mage_Catalog_Model_Product_Type::TYPE_SIMPLE,
+            'stock_data'        => array( 'is_in_stock' => 1, 'qty' => 99999 ),
+            'sku'               => $data['sku']
         );
 
         $this->productModel->shouldReceive('getIdBySku')->with('sku1')->once()->andReturn(123);
-
         $this->productModel->shouldReceive('getData')
             ->once()->andReturn(array('loaded_attr' => 27));
         $this->productModel->shouldReceive('setWebsiteIds')->with(array())

--- a/spec/MageTest/MagentoExtension/Fixture/ProductSpec.php
+++ b/spec/MageTest/MagentoExtension/Fixture/ProductSpec.php
@@ -22,6 +22,7 @@
  */
 namespace spec\MageTest\MagentoExtension\Fixture;
 
+use MageTest\MagentoExtension\Helper\Website;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 
@@ -46,8 +47,13 @@ class ProductSpec extends ObjectBehavior
         // Class is final, we can only use a partial mock
         $this->productModel = $productModel = \Mockery::mock(new \Mage_Catalog_Model_Product);
 
+        $websiteHelper = \Mockery::mock(new Website());
+        $websiteHelper->shouldReceive('getWebsiteIds')->andReturn(array());
+        $websiteHelper->shouldReceive('getWebsites')->andReturn(array());
+
         $factory = function () use ($productModel) { return $productModel; };
-        $this->beConstructedWith($factory);
+
+        $this->beConstructedWith($factory, $websiteHelper);
 
         $entityType = \Mockery::mock(new \Mage_Eav_Model_Entity_Type);
         $entityType->shouldReceive('getDefaultAttributeSetId')->andReturn(7);
@@ -78,8 +84,9 @@ class ProductSpec extends ObjectBehavior
 
         $this->productModel->shouldReceive('setWebsiteIds')->with(array())
             ->once()->andReturn($this->productModel)->ordered();
-        $this->productModel->shouldReceive('setData')
-            ->with(\Mockery::any())->once()->andReturn($this->productModel)->ordered();
+        $this->productModel->shouldReceive('setTypeId')->with(\Mage_Catalog_Model_Product_Type::TYPE_SIMPLE)->andReturn($this->productModel);
+        $this->productModel->shouldReceive('getTypeId')->andReturn(\Mage_Catalog_Model_Product_Type::TYPE_SIMPLE);
+        $this->productModel->shouldReceive('setData')->with(\Mockery::any())->once()->andReturn($this->productModel)->ordered();
         $this->productModel->shouldReceive('save')->once()->andReturn(true)->ordered();
         $this->productModel->shouldReceive('getId')->andReturn(1);
         $this->productModel->shouldReceive('getIdBySku')->andReturn(false);

--- a/spec/MageTest/MagentoExtension/Service/Config/CoreConfigSpec.php
+++ b/spec/MageTest/MagentoExtension/Service/Config/CoreConfigSpec.php
@@ -38,31 +38,31 @@ use Prophecy\Argument;
 class CoreConfigSpec extends ObjectBehavior
 {
     /**
-     * @param Mage_Core_Model_Config $coreConfigModel
+     * @param \Mage_Core_Model_Config $coreConfigModel
      */
     function let($coreConfigModel)
     {
         $this->beConstructedWith($coreConfigModel);
     }
 
-    function it_should_retrieve_a_Mage_Core_Model_Config_Collection($coreConfigModel, $coreConfigModelCollection)
-    {
-        // TODO to be completed
-        // $coreConfigModelCollection->isAMockOf(
-        //     'Mage_Core_Model_Resource_Config_Data_Collection'
-        // );
-        // $coreConfigModelCollection->count()
-        //     ->shouldBeCalled()
-        //     ->willReturn(1);
-        // $coreConfigModelCollection->load()
-        //     ->shouldBeCalled()
-        //     ->willReturn(array());
-        //
-        // $coreConfigModel->getCollection()
-        //     ->shouldBeCalled()
-        //     ->willReturn($coreConfigModelCollection);
-        // $coreConfigModel->addFieldToFilter()
-        //     ->shouldBeCalled();
-        // $this->coreConfig->set('path/to/config', 'value');
-    }
+//    function it_should_retrieve_a_Mage_Core_Model_Config_Collection($coreConfigModel, $coreConfigModelCollection)
+//    {
+//        // TODO to be completed
+//        // $coreConfigModelCollection->isAMockOf(
+//        //     'Mage_Core_Model_Resource_Config_Data_Collection'
+//        // );
+//        // $coreConfigModelCollection->count()
+//        //     ->shouldBeCalled()
+//        //     ->willReturn(1);
+//        // $coreConfigModelCollection->load()
+//        //     ->shouldBeCalled()
+//        //     ->willReturn(array());
+//        //
+//        // $coreConfigModel->getCollection()
+//        //     ->shouldBeCalled()
+//        //     ->willReturn($coreConfigModelCollection);
+//        // $coreConfigModel->addFieldToFilter()
+//        //     ->shouldBeCalled();
+//        // $this->coreConfig->set('path/to/config', 'value');
+//    }
 }

--- a/src/MageTest/MagentoExtension/Fixture/Product.php
+++ b/src/MageTest/MagentoExtension/Fixture/Product.php
@@ -21,9 +21,9 @@
  * @copyright  Copyright (c) 2012-2013 MageTest team and contributors.
  */
 namespace MageTest\MagentoExtension\Fixture;
+
 use MageTest\MagentoExtension\Fixture;
 use MageTest\MagentoExtension\Helper\Website;
-use MageTest\MagentoExtension\Helper\WebsiteHelperInterface;
 
 /**
  * Product fixtures functionality provider
@@ -36,14 +36,12 @@ use MageTest\MagentoExtension\Helper\WebsiteHelperInterface;
  */
 class Product implements FixtureInterface
 {
-    const MAGE_PRODUCT_MODEL_PATH = 'catalog/product';
-
     private $modelFactory = null;
     private $model;
     private $defaultAttributes;
 
     /**
-     * @var \MageTest\MagentoExtension\Helper\WebsiteHelperInterface
+     * @var \MageTest\MagentoExtension\Helper\Website
      */
     protected $websiteHelper;
 
@@ -79,7 +77,6 @@ class Product implements FixtureInterface
         if (!empty($attributes['type_id'])) {
             $this->model->setTypeId($attributes['type_id']);
         }
-
 
         $this->validateAttributes(array_keys($attributes));
 
@@ -127,7 +124,6 @@ class Product implements FixtureInterface
         $model->delete();
     }
 
-
     /**
      * retrieve default product model factory
      *
@@ -136,7 +132,7 @@ class Product implements FixtureInterface
     public function defaultModelFactory()
     {
         return function () {
-            return \Mage::app()->getModel(self::MAGE_PRODUCT_MODEL_PATH);
+            return \Mage::app()->getModel('catalog/product');
         };
     }
 
@@ -149,7 +145,6 @@ class Product implements FixtureInterface
     {
         return new Website();
     }
-
 
     protected function sanitizeAttributes($attributes)
     {

--- a/src/MageTest/MagentoExtension/Helper/Website.php
+++ b/src/MageTest/MagentoExtension/Helper/Website.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace MageTest\MagentoExtension\Helper;
+
+/**
+ * Class Website
+ * @package MageTest\MagentoExtension\Helper
+ */
+class Website
+{
+    /**
+     * @param null $withDefault
+     * @param bool $codeKey
+     * @return array
+     */
+    public function getWebsites($withDefault = null, $codeKey = false)
+    {
+        return \Mage::app()->getWebsites($withDefault, $codeKey);
+    }
+
+    /**
+     * @return array
+     */
+    public function getWebsiteIds()
+    {
+        /** @var \Mage_Core_Model_Website $coreWebsite */
+        $coreWebsite = \Mage::app()->getModel('core/website');
+        $ids = array();
+
+        foreach ($coreWebsite->getCollection() as $website) {
+            $ids[] = $website->getId();
+        }
+
+        return $ids;
+    }
+
+} 

--- a/src/MageTest/MagentoExtension/Helper/Website.php
+++ b/src/MageTest/MagentoExtension/Helper/Website.php
@@ -23,11 +23,8 @@ class Website
      */
     public function getWebsiteIds()
     {
-        /** @var \Mage_Core_Model_Website $coreWebsite */
-        $coreWebsite = \Mage::app()->getModel('core/website');
         $ids = array();
-
-        foreach ($coreWebsite->getCollection() as $website) {
+        foreach (\Mage::app()->getModel('core/website')->getCollection() as $website) {
             $ids[] = $website->getId();
         }
 

--- a/src/MageTest/MagentoExtension/Helper/Website.php
+++ b/src/MageTest/MagentoExtension/Helper/Website.php
@@ -1,10 +1,35 @@
 <?php
-
+/**
+ * BehatMage
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License, that is bundled with this
+ * package in the file LICENSE.
+ * It is also available through the world-wide-web at this URL:
+ *
+ * http://opensource.org/licenses/MIT
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email
+ * to <magetest@sessiondigital.com> so we can send you a copy immediately.
+ *
+ * @category   MageTest
+ * @package    MagentoExtension
+ * @subpackage Helper
+ *
+ * @copyright  Copyright (c) 2012-2013 MageTest team and contributors.
+ */
 namespace MageTest\MagentoExtension\Helper;
 
 /**
- * Class Website
- * @package MageTest\MagentoExtension\Helper
+ * Website helper
+ *
+ * @category   MageTest
+ * @package    MagentoExtension
+ * @subpackage Helper
+ *
+ * @author     MageTest team (https://github.com/MageTest/BehatMage/contributors)
  */
 class Website
 {
@@ -30,5 +55,4 @@ class Website
 
         return $ids;
     }
-
-} 
+}


### PR DESCRIPTION
- Refactored Product fixture by extracting responsibility (_getWebsiteIds_ and such) and by introducing the concept of "helpers". A _Website_ helper has been created to help the Product fixture getting what's related to "_websites_".
- Adjusted ProductSpec accordingly.
- Commented completely CoreConfigSpec's pending spec causing PhpSpec to return non-zero value 
  (there is a TODO in the code).

Hopefully with this we should be back to green :P
