### PR TITLE
Add created at to all products created

### DIFF
--- a/spec/MageTest/MagentoExtension/Fixture/ProductSpec.php
+++ b/spec/MageTest/MagentoExtension/Fixture/ProductSpec.php
@@ -90,6 +90,10 @@ class ProductSpec extends ObjectBehavior
 
         $this->productModel->shouldReceive('setWebsiteIds')->with(array())
             ->once()->andReturn($this->productModel)->ordered();
+
+        $this->productModel->shouldReceive('setCreatedAt')->with(null)
+            ->once()->andReturn($this->productModel);
+
         $this->productModel->shouldReceive('setTypeId')->with(\Mage_Catalog_Model_Product_Type::TYPE_SIMPLE)->andReturn($this->productModel);
         $this->productModel->shouldReceive('getTypeId')->andReturn(\Mage_Catalog_Model_Product_Type::TYPE_SIMPLE);
         $this->productModel->shouldReceive('setData')->with(\Mockery::any())->once()->andReturn($this->productModel)->ordered();
@@ -123,6 +127,8 @@ class ProductSpec extends ObjectBehavior
 
         $this->productModel->shouldReceive('setWebsiteIds')->with(array())
             ->once()->andReturn($this->productModel)->ordered();
+        $this->productModel->shouldReceive('setCreatedAt')->with(null)
+            ->once()->andReturn($this->productModel);
         $this->productModel->shouldReceive('setData')
             ->with(\Mockery::any())->once()->andReturn($this->productModel)->ordered();
         $this->productModel->shouldReceive('save')->once()->andReturn(true)->ordered();
@@ -159,6 +165,8 @@ class ProductSpec extends ObjectBehavior
             ->once()->andReturn(array('loaded_attr' => 27));
         $this->productModel->shouldReceive('setWebsiteIds')->with(array())
             ->once()->andReturn($this->productModel)->ordered();
+        $this->productModel->shouldReceive('setCreatedAt')->with(null)
+            ->once()->andReturn($this->productModel);
         $this->productModel->shouldReceive('setData')
             ->with(\Mockery::any())->once()->andReturn($this->productModel)->ordered();
         $this->productModel->shouldReceive('save')->once()->andReturn(true)->ordered();
@@ -176,6 +184,8 @@ class ProductSpec extends ObjectBehavior
 
         $this->productModel->shouldReceive('setWebsiteIds')->with(array())
             ->once()->andReturn($this->productModel)->ordered();
+        $this->productModel->shouldReceive('setCreatedAt')->with(null)
+            ->once()->andReturn($this->productModel);
         $this->productModel->shouldReceive('setData')->once()->andReturn($this->productModel)->ordered();
         $this->productModel->shouldReceive('save')->once()->andReturn(true)->ordered();
         $this->productModel->shouldReceive('getId')->once()->andReturn(554)->ordered();

--- a/src/MageTest/MagentoExtension/Fixture/Product.php
+++ b/src/MageTest/MagentoExtension/Fixture/Product.php
@@ -84,6 +84,7 @@ class Product implements FixtureInterface
                 return $website->getId();
             }, $websiteHelper->getWebsites()))
             ->setData($this->mergeAttributes($attributes))
+            ->setCreatedAt(null)
             ->save();
 
         \Mage::app()->setCurrentStore(\Mage_Core_Model_App::DISTRO_STORE_ID);


### PR DESCRIPTION
Resolves the null date issue reported within magento 1.9 on product creation using the product fixture.
