### PR TITLE
Add media gallery to product fixture with updated product spec

### DIFF
--- a/spec/MageTest/MagentoExtension/Fixture/ProductSpec.php
+++ b/spec/MageTest/MagentoExtension/Fixture/ProductSpec.php
@@ -100,7 +100,8 @@ class ProductSpec extends ObjectBehavior
         $this->model->shouldReceive('setCreatedAt')->with(null)
             ->once()->andReturn($this->model);
 
-        $this->model->shouldReceive('addImageToMediaGallery')->with('image.jpg', ['thumbnail', 'small_image', 'image'], false,
+        $this->model->shouldReceive('addImageToMediaGallery')->with('image.jpg', array('thumbnail', 'small_image',
+        'image'), false,
             false)->once()->andReturn(true)->ordered();
 
         $this->model->shouldReceive('setTypeId')->with(\Mage_Catalog_Model_Product_Type::TYPE_SIMPLE)->andReturn($this->model);

--- a/spec/MageTest/MagentoExtension/Fixture/ProductSpec.php
+++ b/spec/MageTest/MagentoExtension/Fixture/ProductSpec.php
@@ -100,6 +100,9 @@ class ProductSpec extends ObjectBehavior
         $this->model->shouldReceive('setCreatedAt')->with(null)
             ->once()->andReturn($this->model);
 
+        $this->model->shouldReceive('addImageToMediaGallery')->with('image.jpg', ['thumbnail', 'small_image', 'image'], false,
+            false)->once()->andReturn(true)->ordered();
+
         $this->model->shouldReceive('setTypeId')->with(\Mage_Catalog_Model_Product_Type::TYPE_SIMPLE)->andReturn($this->model);
         $this->model->shouldReceive('getTypeId')->andReturn(\Mage_Catalog_Model_Product_Type::TYPE_SIMPLE);
         $this->model->shouldReceive('setData')->with(\Mockery::any())->once()->andReturn($this->model)->ordered();

--- a/src/MageTest/MagentoExtension/Fixture/Product.php
+++ b/src/MageTest/MagentoExtension/Fixture/Product.php
@@ -84,16 +84,7 @@ class Product implements FixtureInterface
 
         \Mage::app()->setCurrentStore(\Mage_Core_Model_App::ADMIN_STORE_ID);
 
-        if (!empty($attributes['image'])) {
-            if (!$imagePath = getcwd() . DIRECTORY_SEPARATOR . $attributes['image']) {
-                throw new \RuntimeException("Image asset not found. $imagePath");
-            }
-
-            $visibility = array('thumbnail', 'small_image', 'image');
-            $this->model
-                ->addImageToMediaGallery($imagePath, $visibility, false, false)
-                ->save();
-        }
+        $this->setProductImageAssets($attributes);
 
         $this->model
             ->setWebsiteIds(array_map(function($website) {
@@ -211,5 +202,24 @@ class Product implements FixtureInterface
             ->getResource()
             ->getEntityType()
             ->getDefaultAttributeSetId();
+    }
+
+    /**
+     * Set media assets against a product if passed via example table.
+     *
+     * @param array $attributes
+     */
+    private function setProductImageAssets(array $attributes)
+    {
+        if (!empty($attributes['image'])) {
+            if (!$imagePath = getcwd() . DIRECTORY_SEPARATOR . $attributes['image']) {
+                throw new \RuntimeException("Image asset not found. $imagePath");
+            }
+
+            $visibility = array('thumbnail', 'small_image', 'image');
+            $this->model
+                ->addImageToMediaGallery($imagePath, $visibility, false, false)
+                ->save();
+        }
     }
 }

--- a/src/MageTest/MagentoExtension/Fixture/Product.php
+++ b/src/MageTest/MagentoExtension/Fixture/Product.php
@@ -80,6 +80,17 @@ class Product implements FixtureInterface
 
         \Mage::app()->setCurrentStore(\Mage_Core_Model_App::ADMIN_STORE_ID);
 
+        if (!empty($attributes['image'])) {
+            if (!$imagePath = getcwd() . DIRECTORY_SEPARATOR . $attributes['image']) {
+                throw new \RuntimeException("Image asset not found. $imagePath");
+            }
+
+            $visibility = array('thumbnail', 'small_image', 'image');
+            $this->model
+                ->addImageToMediaGallery($imagePath, $visibility, false, false)
+                ->save();
+        }
+
         $this->model
             ->setWebsiteIds(array_map(function($website) {
                 return $website->getId();


### PR DESCRIPTION
Allow products to be created with an image. 

``` text
    Given the following products exist:
      | name | sku  | type_id | price | tax_class_id | image                                          | category_ids |
      | test    | test  | simple  | 10.00 | 2                  | features/assets/placeholder.png | 2                   |
```
