### PR TITLE
Force created at attribute.

### DIFF
--- a/src/MageTest/MagentoExtension/Fixture/Product.php
+++ b/src/MageTest/MagentoExtension/Fixture/Product.php
@@ -85,6 +85,7 @@ class Product implements FixtureInterface
                 return $website->getId();
             }, $websiteHelper->getWebsites()))
             ->setData($this->mergeAttributes($attributes))
+            ->setCreatedAt(null)
             ->save();
 
         \Mage::app()->setCurrentStore(\Mage_Core_Model_App::DISTRO_STORE_ID);


### PR DESCRIPTION
Prevent "Unable to create the Magento fixture No date part in '' found" error.
