### PR TITLE
Avoid MySQL integrity constraint violation

### DIFF
--- a/src/MageTest/MagentoExtension/Fixture/Product.php
+++ b/src/MageTest/MagentoExtension/Fixture/Product.php
@@ -92,7 +92,8 @@ class Product implements FixtureInterface
             }, $websiteHelper->getWebsites()))
             ->setData($this->mergeAttributes($attributes))
             ->setCreatedAt(null)
-            ->save();
+            ->getResource()
+            ->save($this->model);
 
         \Mage::app()->setCurrentStore(\Mage_Core_Model_App::DISTRO_STORE_ID);
 


### PR DESCRIPTION
I followed the sample in README and on my second run of the test, it showed this error.

Unable to create the Magento fixture SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '1-1' for key 'UNQ_CATALOGINVENTORY_STOCK_ITEM_PRODUCT_ID_STOCK_ID'

I followed the solution in this page (http://www.magentocommerce.com/boards/viewthread/300959/)
