### PR TITLE
Avoid MySQL integrity constraint violation (updated tests for #62)

### DIFF
--- a/spec/MageTest/MagentoExtension/Fixture/ProductSpec.php
+++ b/spec/MageTest/MagentoExtension/Fixture/ProductSpec.php
@@ -66,8 +66,9 @@ class ProductSpec extends ObjectBehavior
 
         $productResourceModel = \Mockery::mock('Mage_Catalog_Model_Resource_Product');
         $productResourceModel->shouldReceive('getEntityType')->andReturn($entityType);
+        $productResourceModel->shouldReceive('save')->andReturnSelf();
 
-        $this->model->shouldReceive('getResource')->andReturn($productResourceModel)->ordered();
+        $this->model->shouldReceive('getResource')->andReturn($productResourceModel);
         $this->model->shouldReceive('getAttributes')->andReturn(array());
     }
 

--- a/src/MageTest/MagentoExtension/Fixture/Product.php
+++ b/src/MageTest/MagentoExtension/Fixture/Product.php
@@ -92,7 +92,8 @@ class Product implements FixtureInterface
             }, $websiteHelper->getWebsites()))
             ->setData($this->mergeAttributes($attributes))
             ->setCreatedAt(null)
-            ->save();
+            ->getResource()
+            ->save($this->model);
 
         \Mage::app()->setCurrentStore(\Mage_Core_Model_App::DISTRO_STORE_ID);
 


### PR DESCRIPTION
I've updated the specs in line with the change that @vernard performed in #62.  I couldn't see the value of having that `->ordered()` call there, feel free to educate!
