### PR TITLE
Start testing against 5.5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ php:
   - 5.3
   # aliased to a recent 5.4.x version
   - 5.4
+  # aliased to a recent 5.5.x version
+  - 5.5
 
 before_script:
   - composer install --dev


### PR DESCRIPTION
Couldn't see a reason not to do this.  Tested on my personal fork with Travis and it's passing fine.
