### PR TITLE
Expose FixtureFactory in MagentoContext

### DIFF
--- a/spec/MageTest/MagentoExtension/Context/MagentoContextSpec.php
+++ b/spec/MageTest/MagentoExtension/Context/MagentoContextSpec.php
@@ -60,4 +60,10 @@ class MagentoContextSpec extends ObjectBehavior
         $factory->create('product', $dataRow)->shouldBeCalled();
         $this->theProductsExist($table);
     }
+
+    function it_should_expose_the_fixture_factory(FixtureFactory $factory)
+    {
+        $this->getFixtureFactory()->shouldReturn($factory);
+    }
+
 }

--- a/src/MageTest/MagentoExtension/Context/MagentoContext.php
+++ b/src/MageTest/MagentoExtension/Context/MagentoContext.php
@@ -211,6 +211,11 @@ CONF;
         $this->factory = $factory;
     }
 
+    public function getFixtureFactory()
+    {
+        return $this->factory;
+    }
+
     public function setSessionService(Session $session)
     {
         $this->sessionService = $session;


### PR DESCRIPTION
I discovered an issue using fixtures when extending from `MagentoContext`. I found I couldn't access the `FixtureFactory` unless I extended from `RawMagentoContext` (which has a `getFixtureFactory()` method) - but that caused problems because it contains all the steps defined in `MinkContext`, which caused duplication and threw ambiguous exceptions.

My solution to this was to implement `getFixtureFactory()` in `MagentoContext`. It seems like this method was omitted originally, as all the other private properties (`$app`, `$configManager`, `$cacheManager`, `$sessionService`) have getters and setters, but `$factory` only has a setter, and then `getFixture()`. 

I'm not sure whether this omission was intentional or accidental, I think the original intention was to use `getFixture()` to return these objects, but a change in the `FixtureFactory` implementation means this no longer works.
