### PR TITLE
Fill attribute_set_id and default type_id

### DIFF
--- a/spec/MageTest/MagentoExtension/Fixture/ProductSpec.php
+++ b/spec/MageTest/MagentoExtension/Fixture/ProductSpec.php
@@ -70,6 +70,8 @@ class ProductSpec extends ObjectBehavior
 
         $this->model->shouldReceive('getResource')->andReturn($productResourceModel);
         $this->model->shouldReceive('getAttributes')->andReturn(array());
+        $this->model->shouldReceive('setAttributeSetId')->andReturn($productModel);
+        $this->model->shouldReceive('setTypeId')->andReturn($productModel);
     }
 
     function it_should_throw_exception_if_sku_is_not_defined()
@@ -220,5 +222,24 @@ class ProductSpec extends ObjectBehavior
         $this->model->shouldReceive('delete')->once()->andReturn(null)->ordered();
 
         $this->delete(554);
+    }
+
+    function it_should_fill_attribute_set_and_type_id_before_loading_attributes()
+    {
+        $productData = array(
+            'sku' => 'test_sku',
+            'attribute_set_id' => 123,
+        );
+
+        $this->model->shouldReceive('setData')->andReturn($this->model);
+        $this->model->shouldReceive('setCreatedAt')->andReturn($this->model);
+        $this->model->shouldReceive('setWebsiteIds')->andReturn($this->model);
+        $this->model->shouldReceive('getIdBySku')->andReturn(false);
+
+        $this->model->shouldReceive('setAttributeSetId')->with(123)->once()->ordered();
+        $this->model->shouldReceive('setTypeId')->with('simple')->atLeast()->once()->ordered();
+        $this->model->shouldReceive('getAttributes')->atLeast()->once()->ordered();
+
+        $this->create($productData);
     }
 }

--- a/src/MageTest/MagentoExtension/Fixture/Product.php
+++ b/src/MageTest/MagentoExtension/Fixture/Product.php
@@ -80,6 +80,10 @@ class Product implements FixtureInterface
             $this->model->setTypeId($attributes['type_id']);
         }
 
+        if (!empty($attributes['attribute_set_id'])) {
+            $this->model->setAttributeSetId($attributes['attribute_set_id']);
+        }
+
         $this->validateAttributes(array_keys($attributes));
 
         \Mage::app()->setCurrentStore(\Mage_Core_Model_App::ADMIN_STORE_ID);
@@ -169,6 +173,11 @@ class Product implements FixtureInterface
     protected function getDefaultAttributes()
     {
         $productModel = $this->serviceContainer['productModel']();
+
+        if ($productModel->getTypeId() == '') {
+            $productModel->setTypeId(\Mage_Catalog_Model_Product_Type::TYPE_SIMPLE);
+        }
+
         $typeId       = $productModel->getTypeId();
 
         if ($this->defaultAttributes[$typeId]) {


### PR DESCRIPTION
This change fixes product attribute validation. Without it the "$attribute is not yet defined as an attribute of Product" error message will be shown for attributes belongs to a custom attribute set (e.g. Clothing attribute set and color attribute).
