### PR TITLE
Fix add image assets when creating product fixture

### DIFF
--- a/src/MageTest/MagentoExtension/Fixture/Product.php
+++ b/src/MageTest/MagentoExtension/Fixture/Product.php
@@ -84,16 +84,16 @@ class Product implements FixtureInterface
 
         \Mage::app()->setCurrentStore(\Mage_Core_Model_App::ADMIN_STORE_ID);
 
-        $this->setProductImageAssets($attributes);
-
         $this->model
             ->setWebsiteIds(array_map(function($website) {
                 return $website->getId();
             }, $websiteHelper->getWebsites()))
             ->setData($this->mergeAttributes($attributes))
-            ->setCreatedAt(null)
-            ->getResource()
-            ->save($this->model);
+            ->setCreatedAt(null);
+
+        $this->setProductImageAssets($attributes);
+
+        $this->model->save();
 
         \Mage::app()->setCurrentStore(\Mage_Core_Model_App::DISTRO_STORE_ID);
 
@@ -218,9 +218,7 @@ class Product implements FixtureInterface
             }
 
             $visibility = array('thumbnail', 'small_image', 'image');
-            $this->model
-                ->addImageToMediaGallery($imagePath, $visibility, false, false)
-                ->save();
+            $this->model->addImageToMediaGallery($imagePath, $visibility, false, false);
         }
     }
 }


### PR DESCRIPTION
Reorder the product fixture `create()` method to prevent the `save()` method being called prematurely on the product model when adding images to the media gallery.

I discovered this issue whilst trying to set an image when creating a product fixture. This gave me the following error when running Behat:

```
Unable to create the Magento fixture SQLSTATE[23000]: Integrity constraint violation: 1452 Cannot add or update a child row: a foreign key constraint fails (`magentodb`.`catalog_product_entity`, CONSTRAINT `FK_CAT_PRD_ENTT_ATTR_SET_ID_EAV_ATTR_SET_ATTR_SET_ID` FOREIGN KEY (`attribute_set_id`) REFERENCES `eav_attribute_set` (`attribute_set_id`) ON )
```

Eventually I found this was related to the attribute set not existing, more specifically, no attribute set id was used when the `save()` method was first called on the product. This was due to the `setProductImageAssets()` saving the product when adding images to the media gallery, prior to the attribute data being set on the model.

Deferring this process, and removing the duplicate call to `save()`, allowed me to successfully create product fixtures both with and without images.
