### PR TITLE
Update composer.json to support later versions of behat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "~5.3",
-        "behat/behat": "3.0.15",
+        "behat/behat": "^3.0.15",
         "behat/mink-extension": "~2",
         "behat/mink-goutte-driver": "~1.1.0"
     },


### PR DESCRIPTION
Behat 3.1 has been released almost a year ago. Having such a restricted version specified in the composer.json means projects using this library can't use Behat 3.1+ (3.3 released in December)