### PR TITLE
Set minimum PHP version to 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,19 @@ php:
   # using major version aliases
 
   # aliased to a recent 5.3.x version
-  - 5.3
+  - "5.3"
   # aliased to a recent 5.4.x version
-  - 5.4
+  - "5.4"
   # aliased to a recent 5.5.x version
-  - 5.5
+  - "5.5"
+  # aliased to a recent 5.6.x version
+  - "5.6"
+  # aliased to a recent 7.0.x version
+  - "7.0"
+  # aliased to a recent 7.1.x version
+  - "7.1"
+  # aliased to a recent 7.2.x version
+  - "7.2"
 
 before_script:
   - composer install --dev

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/MageTest/BehatMage",
     "license": "MIT",
     "require": {
-        "php": "~5.3",
+        "php": ">=5.3",
         "behat/behat": "~2.4.4",
         "behat/mink-extension": "*",
         "behat/mink-browserkit-driver": "*",


### PR DESCRIPTION
Set minimum PHP version to 5.3 to allow this library to be used in a PHP 7+ context.
Updated Travis to build the project on PHP 7.0, 7.1 and 7.2